### PR TITLE
use browser flag for node resolve

### DIFF
--- a/src/cjs-transform.js
+++ b/src/cjs-transform.js
@@ -97,6 +97,7 @@ class CJSTransform extends Plugin {
       input: path.posix.join(this.projectRoot, relativePath),
       plugins: [
         resolve({
+          browser: true,
           customResolveOptions: {
             moduleDirectory: path.join(this.projectRoot, 'node_modules'),
           },


### PR DESCRIPTION
`rollup-plugin-node-resolve` has an optional `browser` flag that, when turned on, will respect the `browser` field in a library's `package.json` if it exists.

From the README:
```
// some package.json files have a `browser` field which
// specifies alternative files to load for people bundling
// for the browser. If that's you, use this option, otherwise
// pkg.browser will be ignored
```

Given that this is an ember transform, it is almost certainly true that consumers of this addon will always be bundling for the browser, so it makes sense to turn this flag on.

In practice, this came up with the `uuid` package, which imports the node `crypto` library by default (and which therefore breaks in browsers), but it has a `browser` field that points at alternative files that do not require `crypto`.

I've tested this change locally with `uuid` and confirmed that the browser flag does result in `uuid` importing the correct files and therefore works in the browser.