### PR TITLE
fix: use node's lookup algorithm to find node modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "hash-for-dep": "^1.2.3",
     "pkg-dir": "^2.0.0",
     "rollup": "^0.59.0",
+    "resolve": "^1.7.1",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "username": "^3.0.0"

--- a/src/cjs-transform.js
+++ b/src/cjs-transform.js
@@ -33,17 +33,17 @@ function ensureCachePopulated(cacheKey, buildFunction) {
 class CJSTransform extends Plugin {
   /**
    * @param {string} input - absolute path to source directory
-   * @param {string} projectRoot - absolute path to project root. Used as the reference directory to find NPM packages via node's `require` algorithm
+   * @param {string} parentRoot - absolute path to parent (project or addon) root. Used as the reference directory to find NPM packages via node's `require` algorithm
    * @param {Object} options - map of relative file paths to rollup options, i.e. { "node_modules/foo/bar.js": { as: 'foo' } }
    */
-  constructor(input, projectRoot, options) {
+  constructor(input, parentRoot, options) {
     super([input], {
       name: 'CJSTransform',
       annotation: 'CJS Transform',
       persistentOutput: true,
     });
 
-    this.projectRoot = projectRoot;
+    this.parentRoot = parentRoot;
     this.options = options;
     this.hasBuilt = false;
     this.cacheKey = path.join('cjs-transform', this.calculateCacheKey());
@@ -84,7 +84,7 @@ class CJSTransform extends Plugin {
 
     for (let relativePath in this.options) {
       let fullPath = resolveSync(relativePath.slice(NODE_MODULES.length), {
-        basedir: this.projectRoot,
+        basedir: this.parentRoot,
       });
       let packageDir = pkgDir.sync(fullPath);
       let hash = hashForDep(packageDir);
@@ -110,7 +110,7 @@ begins with "node_modules/".`);
     }
 
     const fullPath = resolveSync(relativePath.slice(NODE_MODULES.length), {
-      basedir: this.projectRoot,
+      basedir: this.parentRoot,
     });
 
     let inputOptions = {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = {
     const BroccoliDebug = require('broccoli-debug');
     const CJSTransform = require('./cjs-transform');
 
-    let project = this.project;
+    let parent = this.parent;
     let debugTree = BroccoliDebug.buildDebugCallback('ember-cli-cjs-transform');
 
     return {
@@ -15,7 +15,7 @@ module.exports = {
         transform(tree, options) {
           let input = debugTree(tree, 'input');
 
-          let processed = new CJSTransform(input, project.root, options);
+          let processed = new CJSTransform(input, parent.root, options);
 
           return debugTree(processed, 'output');
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3034,6 +3034,12 @@ resolve@^1.1.6, resolve@^1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.7.1:
+  version "1.7.1"
+  resolved "https://npm.vip.global.square/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"


### PR DESCRIPTION
assuming that the package is inside the project root fails when `npm link`ing or using yarn workspaces.

addresses #23